### PR TITLE
llvm 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ For DMD, this is the `-version` argument; for dub, the `versions` field.
 The identifier to set the LLVM version is defined as
 `LLVM_{MAJOR_VERSION}_{MINOR_VERSION}_{PATCH_VERSION}`, so to get LLVM version 3.1.0 use `LLVM_3_1_0`.
 
-Current supported versions are 3.1.0 - 5.0.0 and if no version is given
-at compile time, 5.0.0 will be assumed.
+Current supported versions are 3.1.0 - 6.0.0 and if no version is given
+at compile time, 6.0.0 will be assumed.
 
 LLVM targets
 ------------

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ For DMD, this is the `-version` argument; for dub, the `versions` field.
 The identifier to set the LLVM version is defined as
 `LLVM_{MAJOR_VERSION}_{MINOR_VERSION}_{PATCH_VERSION}`, so to get LLVM version 3.1.0 use `LLVM_3_1_0`.
 
-Current supported versions are 3.1.0 - 4.0.0 and if no version is given
-at compile time, 4.0.0 will be assumed.
+Current supported versions are 3.1.0 - 5.0.0 and if no version is given
+at compile time, 5.0.0 will be assumed.
 
 LLVM targets
 ------------

--- a/source/llvm/config.d
+++ b/source/llvm/config.d
@@ -7,6 +7,7 @@ import std.algorithm.searching : canFind;
 
 /// LLVM Versions that llvm-d supports
 immutable LLVM_Versions = [
+	[5,0,0],
 	[4,0,0],
 	[3,9,1],
 	[3,9,0],
@@ -59,7 +60,9 @@ immutable LLVM_VersionString = LLVM_VERSION_MAJOR.to!string ~ "." ~ LLVM_VERSION
 immutable LLVM_Targets = {
 	string[] targets;
 	mixin({
-			static if (LLVM_Version >= asVersion(4, 0, 0)) {
+			static if (LLVM_Version >= asVersion(5, 0, 0)) {
+				return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","Mips","MSP430","Nios2","NVPTX","PowerPC","RISCV","Sparc","SystemZ","WebAssembly","X86","XCore"];
+			} else static if (LLVM_Version >= asVersion(4, 0, 0)) {
 				return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","MSP430","Mips","NVPTX","PowerPC","RISCV","Sparc","SystemZ","WebAssembly","X86","XCore"];
 			} else static if (LLVM_Version >= asVersion(3, 9, 0)) {
 				return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","MSP430","Mips","NVPTX","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];
@@ -86,7 +89,9 @@ immutable LLVM_Targets = {
 
 /// LLVM Targets with AsmPrinter capability (if enabled)
 immutable LLVM_AsmPrinters = {
-	static if (LLVM_Version >= asVersion(4, 0, 0)) {
+	static if (LLVM_Version >= asVersion(5, 0, 0)) {
+		return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","Mips","MSP430","NVPTX","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];
+	} else static if (LLVM_Version >= asVersion(4, 0, 0)) {
 		return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","MSP430","Mips","NVPTX","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];
 	} else static if (LLVM_Version >= asVersion(3, 9, 0)) {
 		return ["AArch64","AMDGPU","ARM","BPF","Hexagon","Lanai","MSP430","Mips","NVPTX","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];
@@ -111,7 +116,9 @@ immutable LLVM_AsmPrinters = {
 
 /// LLVM Targets with AsmParser capability (if enabled)
 immutable LLVM_AsmParsers = {
-	static if (LLVM_Version >= asVersion(4, 0, 0)) {
+	static if (LLVM_Version >= asVersion(5, 0, 0)) {
+		return ["AArch64","AMDGPU","ARM","AVR","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","X86"];
+	} else static if (LLVM_Version >= asVersion(4, 0, 0)) {
 		return ["AArch64","AMDGPU","ARM","AVR","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","X86"];
 	} else static if (LLVM_Version >= asVersion(3, 9, 0)) {
 		return ["AArch64","AMDGPU","ARM","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","X86"];
@@ -136,7 +143,9 @@ immutable LLVM_AsmParsers = {
 
 /// LLVM Targets with Disassembler capability (if enabled)
 immutable LLVM_Disassemblers = {
-	static if (LLVM_Version >= asVersion(4, 0, 0)) {
+	static if (LLVM_Version >= asVersion(5, 0, 0)) {
+		return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];
+	} else static if (LLVM_Version >= asVersion(4, 0, 0)) {
 		return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];
 	} else  static if (LLVM_Version >= asVersion(3, 9, 0)) {
 		return ["AArch64","AMDGPU","ARM","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];

--- a/source/llvm/config.d
+++ b/source/llvm/config.d
@@ -7,6 +7,7 @@ import std.algorithm.searching : canFind;
 
 /// LLVM Versions that llvm-d supports
 immutable LLVM_Versions = [
+	[6,0,0],
 	[5,0,0],
 	[4,0,0],
 	[3,9,1],
@@ -60,7 +61,9 @@ immutable LLVM_VersionString = LLVM_VERSION_MAJOR.to!string ~ "." ~ LLVM_VERSION
 immutable LLVM_Targets = {
 	string[] targets;
 	mixin({
-			static if (LLVM_Version >= asVersion(5, 0, 0)) {
+			static if (LLVM_Version >= asVersion(6, 0, 0)) {
+				return ["AArch64","AMDGPU","ARC","ARM","AVR","BPF","Hexagon","Lanai","Mips","MSP430","Nios2","NVPTX","PowerPC","RISCV","Sparc","SystemZ","WebAssembly","X86","XCore"];
+			} else static if (LLVM_Version >= asVersion(5, 0, 0)) {
 				return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","Mips","MSP430","Nios2","NVPTX","PowerPC","RISCV","Sparc","SystemZ","WebAssembly","X86","XCore"];
 			} else static if (LLVM_Version >= asVersion(4, 0, 0)) {
 				return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","MSP430","Mips","NVPTX","PowerPC","RISCV","Sparc","SystemZ","WebAssembly","X86","XCore"];
@@ -89,7 +92,9 @@ immutable LLVM_Targets = {
 
 /// LLVM Targets with AsmPrinter capability (if enabled)
 immutable LLVM_AsmPrinters = {
-	static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	static if (LLVM_Version >= asVersion(6, 0, 0)) {
+		return ["AArch64","AMDGPU","ARC","ARM","AVR","BPF","Hexagon","Lanai","Mips","MSP430","Nios2","NVPTX","PowerPC","RISCV","Sparc","SystemZ","WebAssembly","X86","XCore"];
+	} else static if (LLVM_Version >= asVersion(5, 0, 0)) {
 		return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","Mips","MSP430","NVPTX","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];
 	} else static if (LLVM_Version >= asVersion(4, 0, 0)) {
 		return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","MSP430","Mips","NVPTX","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];
@@ -116,7 +121,9 @@ immutable LLVM_AsmPrinters = {
 
 /// LLVM Targets with AsmParser capability (if enabled)
 immutable LLVM_AsmParsers = {
-	static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	static if (LLVM_Version >= asVersion(6, 0, 0)) {
+		return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","Mips","PowerPC","RISCV","Sparc","SystemZ","X86"];
+	} else static if (LLVM_Version >= asVersion(5, 0, 0)) {
 		return ["AArch64","AMDGPU","ARM","AVR","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","X86"];
 	} else static if (LLVM_Version >= asVersion(4, 0, 0)) {
 		return ["AArch64","AMDGPU","ARM","AVR","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","X86"];
@@ -143,7 +150,9 @@ immutable LLVM_AsmParsers = {
 
 /// LLVM Targets with Disassembler capability (if enabled)
 immutable LLVM_Disassemblers = {
-	static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	static if (LLVM_Version >= asVersion(6, 0, 0)) {
+		return ["AArch64","AMDGPU","ARC","ARM","AVR","BPF","Hexagon","Lanai","Mips","PowerPC","RISCV","Sparc","SystemZ","WebAssembly","X86","XCore"];
+	} else static if (LLVM_Version >= asVersion(5, 0, 0)) {
 		return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];
 	} else static if (LLVM_Version >= asVersion(4, 0, 0)) {
 		return ["AArch64","AMDGPU","ARM","AVR","BPF","Hexagon","Lanai","Mips","PowerPC","Sparc","SystemZ","WebAssembly","X86","XCore"];

--- a/source/llvm/constants.d
+++ b/source/llvm/constants.d
@@ -616,3 +616,95 @@ static if (LLVM_Version >= asVersion(3, 9, 0))
 		LLVMOrcErrGeneric,
 	}
 }
+
+/+ Debug info flags +/
+
+static if (LLVM_Version >= asVersion(6, 0, 0))
+{
+	enum : LLVMDIFlags {
+		LLVMDIFlagZero = 0,
+		LLVMDIFlagPrivate = 1,
+		LLVMDIFlagProtected = 2,
+		LLVMDIFlagPublic = 3,
+		LLVMDIFlagFwdDecl = 1 << 2,
+		LLVMDIFlagAppleBlock = 1 << 3,
+		LLVMDIFlagBlockByrefStruct = 1 << 4,
+		LLVMDIFlagVirtual = 1 << 5,
+		LLVMDIFlagArtificial = 1 << 6,
+		LLVMDIFlagExplicit = 1 << 7,
+		LLVMDIFlagPrototyped = 1 << 8,
+		LLVMDIFlagObjcClassComplete = 1 << 9,
+		LLVMDIFlagObjectPointer = 1 << 10,
+		LLVMDIFlagVector = 1 << 11,
+		LLVMDIFlagStaticMember = 1 << 12,
+		LLVMDIFlagLValueReference = 1 << 13,
+		LLVMDIFlagRValueReference = 1 << 14,
+		LLVMDIFlagReserved = 1 << 15,
+		LLVMDIFlagSingleInheritance = 1 << 16,
+		LLVMDIFlagMultipleInheritance = 2 << 16,
+		LLVMDIFlagVirtualInheritance = 3 << 16,
+		LLVMDIFlagIntroducedVirtual = 1 << 18,
+		LLVMDIFlagBitField = 1 << 19,
+		LLVMDIFlagNoReturn = 1 << 20,
+		LLVMDIFlagMainSubprogram = 1 << 21,
+		LLVMDIFlagIndirectVirtualBase = (1 << 2) | (1 << 5),
+		LLVMDIFlagAccessibility = LLVMDIFlagPrivate | LLVMDIFlagProtected |
+		                          LLVMDIFlagPublic,
+		LLVMDIFlagPtrToMemberRep = LLVMDIFlagSingleInheritance |
+		                           LLVMDIFlagMultipleInheritance |
+		                           LLVMDIFlagVirtualInheritance
+	}
+	enum : LLVMDWARFSourceLanguage {
+		LLVMDWARFSourceLanguageC89,
+		LLVMDWARFSourceLanguageC,
+		LLVMDWARFSourceLanguageAda83,
+		LLVMDWARFSourceLanguageC_plus_plus,
+		LLVMDWARFSourceLanguageCobol74,
+		LLVMDWARFSourceLanguageCobol85,
+		LLVMDWARFSourceLanguageFortran77,
+		LLVMDWARFSourceLanguageFortran90,
+		LLVMDWARFSourceLanguagePascal83,
+		LLVMDWARFSourceLanguageModula2,
+		// New in DWARF v3:
+		LLVMDWARFSourceLanguageJava,
+		LLVMDWARFSourceLanguageC99,
+		LLVMDWARFSourceLanguageAda95,
+		LLVMDWARFSourceLanguageFortran95,
+		LLVMDWARFSourceLanguagePLI,
+		LLVMDWARFSourceLanguageObjC,
+		LLVMDWARFSourceLanguageObjC_plus_plus,
+		LLVMDWARFSourceLanguageUPC,
+		LLVMDWARFSourceLanguageD,
+		// New in DWARF v4:
+		LLVMDWARFSourceLanguagePython,
+		// New in DWARF v5:
+		LLVMDWARFSourceLanguageOpenCL,
+		LLVMDWARFSourceLanguageGo,
+		LLVMDWARFSourceLanguageModula3,
+		LLVMDWARFSourceLanguageHaskell,
+		LLVMDWARFSourceLanguageC_plus_plus_03,
+		LLVMDWARFSourceLanguageC_plus_plus_11,
+		LLVMDWARFSourceLanguageOCaml,
+		LLVMDWARFSourceLanguageRust,
+		LLVMDWARFSourceLanguageC11,
+		LLVMDWARFSourceLanguageSwift,
+		LLVMDWARFSourceLanguageJulia,
+		LLVMDWARFSourceLanguageDylan,
+		LLVMDWARFSourceLanguageC_plus_plus_14,
+		LLVMDWARFSourceLanguageFortran03,
+		LLVMDWARFSourceLanguageFortran08,
+		LLVMDWARFSourceLanguageRenderScript,
+		LLVMDWARFSourceLanguageBLISS,
+		// Vendor extensions:
+		LLVMDWARFSourceLanguageMips_Assembler,
+		LLVMDWARFSourceLanguageGOOGLE_RenderScript,
+		LLVMDWARFSourceLanguageBORLAND_Delphi
+	}
+
+	enum : LLVMDWARFEmissionKind {
+		LLVMDWARFEmissionNone = 0,
+		LLVMDWARFEmissionFull,
+		LLVMDWARFEmissionLineTablesOnly
+	}
+
+}

--- a/source/llvm/functions/link.d
+++ b/source/llvm/functions/link.d
@@ -78,6 +78,9 @@ static if (LLVM_Version >= asVersion(3, 6, 0)) {
 
 void LLVMAddArgumentPromotionPass(LLVMPassManagerRef PM);
 void LLVMAddConstantMergePass(LLVMPassManagerRef PM);
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	void LLVMAddCalledValuePropagationPass(LLVMPassManagerRef PM);
+}
 void LLVMAddDeadArgEliminationPass(LLVMPassManagerRef PM);
 void LLVMAddFunctionAttrsPass(LLVMPassManagerRef PM);
 void LLVMAddFunctionInliningPass(LLVMPassManagerRef PM);
@@ -115,7 +118,7 @@ static if (LLVM_Version >= asVersion(3, 6, 0)) {
     void LLVMAddAlignmentFromAssumptionsPass(LLVMPassManagerRef PM);
 }
 void LLVMAddCFGSimplificationPass(LLVMPassManagerRef PM);
-static if (LLVM_Version >= asVersion(5, 0, 0)) {
+static if (LLVM_Version >= asVersion(5, 0, 0) && LLVM_Version < asVersion(6, 0, 0)) {
 	void LLVMAddLateCFGSimplificationPass(LLVMPassManagerRef PM);
 }
 void LLVMAddDeadStoreEliminationPass(LLVMPassManagerRef PM);
@@ -397,6 +400,12 @@ uint LLVMGetVectorSize(LLVMTypeRef VectorTy);
 LLVMTypeRef LLVMVoidTypeInContext(LLVMContextRef C);
 LLVMTypeRef LLVMLabelTypeInContext(LLVMContextRef C);
 LLVMTypeRef LLVMX86MMXTypeInContext(LLVMContextRef C);
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	LLVMTypeRef LLVMTokenTypeInContext(LLVMContextRef C);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	LLVMTypeRef LLVMMetadataTypeInContext(LLVMContextRef C);
+}
 LLVMTypeRef LLVMVoidType();
 LLVMTypeRef LLVMLabelType();
 LLVMTypeRef LLVMX86MMXType();
@@ -1687,6 +1696,8 @@ static if (LLVM_Version >= asVersion(3, 4, 0)) {
 static if (LLVM_Version >= asVersion(5, 0, 0)) {
 	LLVMSharedModuleRef LLVMOrcMakeSharedModule(LLVMModuleRef Mod);
 	void LLVMOrcDisposeSharedModuleRef(LLVMSharedModuleRef SharedMod);
+}
+static if (LLVM_Version >= asVersion(5, 0, 0) && LLVM_Version < asVersion(6, 0, 0)) {
 	LLVMSharedObjectBufferRef LLVMOrcMakeSharedObjectBuffer(LLVMMemoryBufferRef ObjBuffer);
 	void LLVMOrcDisposeSharedObjectBufferRef(LLVMSharedObjectBufferRef SharedObjBuffer);
 }
@@ -1726,7 +1737,9 @@ static if (LLVM_Version >= asVersion(5, 0, 0)) {
 } else static if (LLVM_Version >= asVersion(3, 8, 0)) {
     LLVMOrcModuleHandle LLVMOrcAddLazilyCompiledIR(LLVMOrcJITStackRef JITStack, LLVMModuleRef Mod, LLVMOrcSymbolResolverFn SymbolResolver, void* SymbolResolverCtx);
 }
-static if (LLVM_Version >= asVersion(5, 0, 0)) {
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	LLVMOrcErrorCode LLVMOrcAddObjectFile(LLVMOrcJITStackRef JITStack, LLVMOrcModuleHandle* RetHandle, LLVMMemoryBufferRef Obj, LLVMOrcSymbolResolverFn SymbolResolver, void* SymbolResolverCtx);
+} else static if (LLVM_Version >= asVersion(5, 0, 0)) {
 	LLVMOrcErrorCode LLVMOrcAddObjectFile(LLVMOrcJITStackRef JITStack, LLVMOrcModuleHandle* RetHandle, LLVMSharedObjectBufferRef Obj, LLVMOrcSymbolResolverFn SymbolResolver, void* SymbolResolverCtx);
 
 } else static if (LLVM_Version >= asVersion(3, 8, 0)) {
@@ -1746,4 +1759,40 @@ static if (LLVM_Version >= asVersion(5, 0, 0)) {
 	LLVMOrcErrorCode LLVMOrcDisposeInstance(LLVMOrcJITStackRef JITStack);
 } else static if (LLVM_Version >= asVersion(3, 8, 0)) {
     void LLVMOrcDisposeInstance(LLVMOrcJITStackRef JITStack);
+}
+
+/+ Debug info flags +/
+
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	uint LLVMDebugMetadataVersion();
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	uint LLVMGetModuleDebugMetadataVersion(LLVMModuleRef Module);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	uint LLVMGetModuleDebugMetadataVersion(LLVMModuleRef Module);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	LLVMBool LLVMStripModuleDebugInfo(LLVMModuleRef Module);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	LLVMDIBuilderRef LLVMCreateDIBuilderDisallowUnresolved(LLVMModuleRef M);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	LLVMDIBuilderRef LLVMCreateDIBuilder(LLVMModuleRef M);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	void LLVMDisposeDIBuilder(LLVMDIBuilderRef Builder);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	void LLVMDIBuilderFinalize(LLVMDIBuilderRef Builder);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(LLVMDIBuilderRef Builder, LLVMDWARFSourceLanguage Lang, LLVMMetadataRef FileRef, const(char)* Producer, size_t ProducerLen, LLVMBool isOptimized, const(char)* Flags, size_t FlagsLen, uint RuntimeVer, const(char)* SplitName, size_t SplitNameLen, LLVMDWARFEmissionKind Kind, uint DWOId, LLVMBool SplitDebugInlining, LLVMBool DebugInfoForProfiling);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	LLVMMetadataRef LLVMDIBuilderCreateFile(LLVMDIBuilderRef Builder, const(char)* Filename, size_t FilenameLen, const(char)* Directory, size_t DirectoryLen);
+}
+static if (LLVM_Version >= asVersion(6, 0, 0)) {
+	LLVMMetadataRef LLVMDIBuilderCreateDebugLocation(LLVMContextRef Ctx, uint Line, uint Column, LLVMMetadataRef Scope, LLVMMetadataRef InlinedAt);
 }

--- a/source/llvm/functions/link.d
+++ b/source/llvm/functions/link.d
@@ -115,6 +115,9 @@ static if (LLVM_Version >= asVersion(3, 6, 0)) {
     void LLVMAddAlignmentFromAssumptionsPass(LLVMPassManagerRef PM);
 }
 void LLVMAddCFGSimplificationPass(LLVMPassManagerRef PM);
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	void LLVMAddLateCFGSimplificationPass(LLVMPassManagerRef PM);
+}
 void LLVMAddDeadStoreEliminationPass(LLVMPassManagerRef PM);
 static if (LLVM_Version >= asVersion(3, 5, 0)) {
     void LLVMAddScalarizerPass(LLVMPassManagerRef PM);
@@ -376,6 +379,12 @@ LLVMBool LLVMIsOpaqueStruct(LLVMTypeRef StructTy);
 /+++ Sequential Types +++/
 
 LLVMTypeRef LLVMGetElementType(LLVMTypeRef Ty);
+static if (LLVM_Version >= asVersion(5,0,0)) {
+	void LLVMGetSubtypes(LLVMTypeRef Tp, LLVMTypeRef* Arr);
+}
+static if (LLVM_Version >= asVersion(5,0,0)) {
+	uint LLVMGetNumContainedTypes(LLVMTypeRef Tp);
+}
 LLVMTypeRef LLVMArrayType(LLVMTypeRef ElementType, uint ElementCount);
 uint LLVMGetArrayLength(LLVMTypeRef ArrayTy);
 LLVMTypeRef LLVMPointerType(LLVMTypeRef ElementType, uint AddressSpace);
@@ -778,6 +787,10 @@ LLVMValueRef LLVMMDStringInContext(LLVMContextRef C, const(char)* Str, uint SLen
 LLVMValueRef LLVMMDString(const(char)* Str, uint SLen);
 LLVMValueRef LLVMMDNodeInContext(LLVMContextRef C, LLVMValueRef* Vals, uint Count);
 LLVMValueRef LLVMMDNode(LLVMValueRef* Vals, uint Count);
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	LLVMValueRef LLVMMetadataAsValue(LLVMContextRef C, LLVMMetadataRef MD);
+	LLVMMetadataRef LLVMValueAsMetadata(LLVMValueRef Val);
+}
 const(char)* LLVMGetMDString(LLVMValueRef V, uint* Len);
 static if (LLVM_Version >= asVersion(3, 2, 0)) {
     uint LLVMGetMDNodeNumOperands(LLVMValueRef V);
@@ -1671,6 +1684,12 @@ static if (LLVM_Version >= asVersion(3, 4, 0)) {
 }
 
 /+ JIT compilation of LLVM IR +/
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	LLVMSharedModuleRef LLVMOrcMakeSharedModule(LLVMModuleRef Mod);
+	void LLVMOrcDisposeSharedModuleRef(LLVMSharedModuleRef SharedMod);
+	LLVMSharedObjectBufferRef LLVMOrcMakeSharedObjectBuffer(LLVMMemoryBufferRef ObjBuffer);
+	void LLVMOrcDisposeSharedObjectBufferRef(LLVMSharedObjectBufferRef SharedObjBuffer);
+}
 static if (LLVM_Version >= asVersion(3, 8, 0)) {
     LLVMOrcJITStackRef LLVMOrcCreateInstance(LLVMTargetMachineRef TM);
 }
@@ -1683,7 +1702,10 @@ static if (LLVM_Version >= asVersion(3, 8, 0)) {
 static if (LLVM_Version >= asVersion(3, 8, 0)) {
     void LLVMOrcDisposeMangledSymbol(char* MangledSymbol);
 }
-static if (LLVM_Version >= asVersion(3, 8, 0)) {
+
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	LLVMOrcErrorCode LLVMOrcCreateLazyCompileCallback(LLVMOrcJITStackRef JITStack, LLVMOrcTargetAddress* RetAddr, LLVMOrcLazyCompileCallbackFn Callback, void* CallbackCtx);
+} else static if (LLVM_Version >= asVersion(3, 8, 0)) {
     LLVMOrcTargetAddress LLVMOrcCreateLazyCompileCallback(LLVMOrcJITStackRef JITStack, LLVMOrcLazyCompileCallbackFn Callback, void* CallbackCtx);
 }
 static if (LLVM_Version >= asVersion(3, 8, 0)) {
@@ -1692,21 +1714,36 @@ static if (LLVM_Version >= asVersion(3, 8, 0)) {
 static if (LLVM_Version >= asVersion(3, 8, 0)) {
     void LLVMOrcSetIndirectStubPointer(LLVMOrcJITStackRef JITStack, const(char)* StubName, LLVMOrcTargetAddress NewAddr);
 }
-static if (LLVM_Version >= asVersion(3, 8, 0)) {
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	LLVMOrcErrorCode LLVMOrcAddEagerlyCompiledIR(LLVMOrcJITStackRef JITStack, LLVMOrcModuleHandle* RetHandle, LLVMSharedModuleRef Mod, LLVMOrcSymbolResolverFn SymbolResolver, void* SymbolResolverCtx);
+
+} else static if (LLVM_Version >= asVersion(3, 8, 0)) {
     LLVMOrcModuleHandle LLVMOrcAddEagerlyCompiledIR(LLVMOrcJITStackRef JITStack, LLVMModuleRef Mod, LLVMOrcSymbolResolverFn SymbolResolver, void* SymbolResolverCtx);
 }
-static if (LLVM_Version >= asVersion(3, 8, 0)) {
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	LLVMOrcErrorCode LLVMOrcAddLazilyCompiledIR(LLVMOrcJITStackRef JITStack, LLVMOrcModuleHandle* RetHandle, LLVMSharedModuleRef Mod, LLVMOrcSymbolResolverFn SymbolResolver, void* SymbolResolverCtx);
+
+} else static if (LLVM_Version >= asVersion(3, 8, 0)) {
     LLVMOrcModuleHandle LLVMOrcAddLazilyCompiledIR(LLVMOrcJITStackRef JITStack, LLVMModuleRef Mod, LLVMOrcSymbolResolverFn SymbolResolver, void* SymbolResolverCtx);
 }
-static if (LLVM_Version >= asVersion(3, 8, 0)) {
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	LLVMOrcErrorCode LLVMOrcAddObjectFile(LLVMOrcJITStackRef JITStack, LLVMOrcModuleHandle* RetHandle, LLVMSharedObjectBufferRef Obj, LLVMOrcSymbolResolverFn SymbolResolver, void* SymbolResolverCtx);
+
+} else static if (LLVM_Version >= asVersion(3, 8, 0)) {
     LLVMOrcModuleHandle LLVMOrcAddObjectFile(LLVMOrcJITStackRef JITStack, LLVMObjectFileRef Obj, LLVMOrcSymbolResolverFn SymbolResolver, void* SymbolResolverCtx);
 }
-static if (LLVM_Version >= asVersion(3, 8, 0)) {
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	LLVMOrcErrorCode LLVMOrcRemoveModule(LLVMOrcJITStackRef JITStack, LLVMOrcModuleHandle H);
+} else static if (LLVM_Version >= asVersion(3, 8, 0)) {
     void LLVMOrcRemoveModule(LLVMOrcJITStackRef JITStack, LLVMOrcModuleHandle H);
 }
-static if (LLVM_Version >= asVersion(3, 8, 0)) {
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	LLVMOrcErrorCode LLVMOrcGetSymbolAddress(LLVMOrcJITStackRef JITStack, LLVMOrcTargetAddress *RetAddr, const(char)* SymbolName);
+} else static if (LLVM_Version >= asVersion(3, 8, 0)) {
     LLVMOrcTargetAddress LLVMOrcGetSymbolAddress(LLVMOrcJITStackRef JITStack, const(char)* SymbolName);
 }
-static if (LLVM_Version >= asVersion(3, 8, 0)) {
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	LLVMOrcErrorCode LLVMOrcDisposeInstance(LLVMOrcJITStackRef JITStack);
+} else static if (LLVM_Version >= asVersion(3, 8, 0)) {
     void LLVMOrcDisposeInstance(LLVMOrcJITStackRef JITStack);
 }

--- a/source/llvm/types.d
+++ b/source/llvm/types.d
@@ -228,9 +228,10 @@ alias int LLVMRelocMode;
 alias int LLVMCodeModel;
 alias int LLVMCodeGenFileType;
 
-static if (LLVM_Version >= asVersion(5, 0, 0))
-{
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
 	struct LLVMOpaqueSharedModule; alias LLVMOpaqueSharedModule* LLVMSharedModuleRef;
+}
+static if (LLVM_Version >= asVersion(5, 0, 0) && LLVM_Version < asVersion(6, 0, 0)) {
 	struct LLVMOpaqueSharedObjectBuffer; alias LLVMOpaqueSharedObjectBuffer* LLVMSharedObjectBufferRef;
 
 }
@@ -257,4 +258,13 @@ static if (LLVM_Version >= asVersion(3, 9, 0))
 		const(char)* Buffer;
 		size_t Size;
 	}
+}
+
+/+ Debug info flags +/
+
+static if (LLVM_Version >= asVersion(6, 0, 0))
+{
+	alias int LLVMDIFlags;
+	alias int LLVMDWARFSourceLanguage;
+	alias int LLVMDWARFEmissionKind;
 }

--- a/source/llvm/types.d
+++ b/source/llvm/types.d
@@ -37,7 +37,13 @@ struct LLVMOpaqueContext {}; alias LLVMOpaqueContext* LLVMContextRef;
 struct LLVMOpaqueModule {}; alias LLVMOpaqueModule* LLVMModuleRef;
 struct LLVMOpaqueType {}; alias LLVMOpaqueType* LLVMTypeRef;
 struct LLVMOpaqueValue {}; alias LLVMOpaqueValue* LLVMValueRef;
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	struct LLVMOpaqueMetadata; alias LLVMOpaqueMetadata* LLVMMetadataRef;
+}
 struct LLVMOpaqueBasicBlock {}; alias LLVMOpaqueBasicBlock* LLVMBasicBlockRef;
+static if (LLVM_Version >= asVersion(5, 0, 0)) {
+	struct LLVMOpaqueDIBuilder; alias LLVMOpaqueDIBuilder* LLVMDIBuilderRef;
+}
 struct LLVMOpaqueBuilder {}; alias LLVMOpaqueBuilder* LLVMBuilderRef;
 struct LLVMOpaqueModuleProvider {}; alias LLVMOpaqueModuleProvider* LLVMModuleProviderRef;
 struct LLVMOpaqueMemoryBuffer {}; alias LLVMOpaqueMemoryBuffer* LLVMMemoryBufferRef;
@@ -45,8 +51,7 @@ struct LLVMOpaquePassManager {}; alias LLVMOpaquePassManager* LLVMPassManagerRef
 struct LLVMOpaquePassRegistry {}; alias LLVMOpaquePassRegistry* LLVMPassRegistryRef;
 struct LLVMOpaqueUse {}; alias LLVMOpaqueUse* LLVMUseRef;
 
-static if (LLVM_Version >= asVersion(3, 9, 0))
-{
+static if (LLVM_Version >= asVersion(3, 9, 0)) {
 	struct LLVMOpaqueAttributeRef {}; alias LLVMOpaqueAttributeRef* LLVMAttributeRef;
 }
 
@@ -222,6 +227,13 @@ alias int LLVMCodeGenOptLevel;
 alias int LLVMRelocMode;
 alias int LLVMCodeModel;
 alias int LLVMCodeGenFileType;
+
+static if (LLVM_Version >= asVersion(5, 0, 0))
+{
+	struct LLVMOpaqueSharedModule; alias LLVMOpaqueSharedModule* LLVMSharedModuleRef;
+	struct LLVMOpaqueSharedObjectBuffer; alias LLVMOpaqueSharedObjectBuffer* LLVMSharedObjectBufferRef;
+
+}
 
 static if (LLVM_Version >= asVersion(3, 8, 0))
 {


### PR DESCRIPTION
added llvm 6.0.0 support based on the git diffs between release_50 and release_60.
currently untested... maybe in some days I will use the 6.0.0 version.